### PR TITLE
Replace the recursive EntityTree with OrderedForest from Graphs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dfc6214b0d00777e47d1f81878c8c511a87b403abde520c485a38d2b8acb582c",
+  "originHash" : "c69da3054392501da4a4d39044d28f7638f50ef0b270d40144e47e82f49ab767",
   "pins" : [
     {
       "identity" : "geometry",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "90247082d2e42f726a6e6a17a877b3ad9a059629",
         "version" : "0.0.5"
+      }
+    },
+    {
+      "identity" : "graphs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RedECSEngine/Graphs.git",
+      "state" : {
+        "revision" : "d8ba813561de4517b7f5517d67c7f6492de72b43",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,8 @@ let package = Package(
             from: "1.1.0"
         ),
 
+        .package(path: "../swift-graphs"),
+
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],
     targets: [
@@ -77,6 +79,7 @@ let package = Package(
                 .product(name: "GeometryAlgorithms", package: "Geometry"),
                 .product(name: "Randomization", package: "Randomization"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "Graphs", package: "swift-graphs"),
                 "TiledInterpreter",
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,10 @@ let package = Package(
             from: "1.1.0"
         ),
 
-        .package(path: "../swift-graphs"),
+        .package(
+            url: "https://github.com/RedECSEngine/Graphs.git",
+            from: "0.1.0"
+        ),
 
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.18.0"),
     ],
@@ -79,7 +82,7 @@ let package = Package(
                 .product(name: "GeometryAlgorithms", package: "Geometry"),
                 .product(name: "Randomization", package: "Randomization"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
-                .product(name: "Graphs", package: "swift-graphs"),
+                .product(name: "Graphs", package: "Graphs"),
                 "TiledInterpreter",
             ]
         ),

--- a/Sources/RedECS/Entity/EntityRepository.swift
+++ b/Sources/RedECS/Entity/EntityRepository.swift
@@ -1,22 +1,24 @@
+import Graphs
+
 public struct EntityRepository: Equatable, Codable {
     public struct Constants {
         public static let rootTreeId = "Root"
     }
-    
+
     public private(set) var entities: [EntityId: GameEntity] = [:]
     public private(set) var tags: [String: Set<EntityId>] = [:]
-    /// Parent/child relationships. Rendering walks this tree, composing each
+    /// Parent/child relationships. Rendering walks this forest, composing each
     /// entity's transform with its ancestors' and honoring `isHidden` subtrees.
-    public private(set) var tree: EntityTree = .init(id: Constants.rootTreeId)
-    
+    public private(set) var hierarchy: OrderedForest<EntityId> = .init()
+
     public init() { }
-    
+
     public subscript(index: EntityId) -> GameEntity? {
         get {
             entities[index]
         }
     }
-    
+
     public var entityIds: Dictionary<String, GameEntity>.Keys {
         entities.keys
     }
@@ -31,28 +33,25 @@ public extension EntityRepository {
         e.tags.forEach { tag in
             tags[tag, default: []].insert(e.id)
         }
-        
-        var parentId = Constants.rootTreeId
-        if let entityParent = e.parentId {
-            parentId = entityParent
+
+        var parentId = e.parentId.flatMap { $0 == Constants.rootTreeId ? nil : $0 }
+        if !hierarchy.insert(e.id, under: parentId) {
+            assertionFailure("Failed to find parent '\(parentId ?? Constants.rootTreeId)' for entity '\(e.id)'")
+            parentId = nil
+            hierarchy.insert(e.id, under: nil)
         }
-        var tree = self.tree
-        let result = insertEntity(e.id, intoTree: &tree, withParent: parentId)
-        self.tree = tree
-        assert(result, "Failed to find parent in tree '\(parentId)'")
-        e.parentId = parentId
+        e.parentId = parentId ?? Constants.rootTreeId
         entities[e.id] = e
     }
-    
+
     mutating func removeEntity(_ id: EntityId) {
-//        assert(entities[id] != nil, "removing already removed entity")
-        entities[id]?.tags.forEach { tag in
-            tags[tag]?.remove(id)
+        let removed = hierarchy.remove(id)
+        for removedId in removed.isEmpty ? [id] : removed {
+            entities[removedId]?.tags.forEach { tag in
+                tags[tag]?.remove(removedId)
+            }
+            entities[removedId] = nil
         }
-        var tree = self.tree
-        _ = removeEntity(id, fromTree: &tree)
-        self.tree = tree
-        entities[id] = nil
     }
 
     /// Adds `tag` to an existing entity, keeping the reverse `tags` index in
@@ -73,92 +72,22 @@ public extension EntityRepository {
     }
 }
 
-// MARK: - Tree Management
+// MARK: - Hierarchy Management
 
 public extension EntityRepository {
     /// Reparents an entity. Passing `nil` moves it back to the root.
     mutating func setParent(of entityId: EntityId, to parentId: EntityId?) {
-        var tree = self.tree
-        moveEntity(entityId, toParent: parentId ?? Constants.rootTreeId, inTree: &tree)
-        self.tree = tree
+        let target = parentId.flatMap { $0 == Constants.rootTreeId ? nil : $0 }
+        guard hierarchy.move(entityId, under: target) else {
+            assertionFailure("Failed to move entity '\(entityId)' under '\(parentId ?? Constants.rootTreeId)'")
+            return
+        }
+        entities[entityId]?.parentId = target ?? Constants.rootTreeId
     }
 
     /// All ids in the subtree rooted at `entityId`, depth-first,
     /// not including `entityId` itself.
     func descendants(of entityId: EntityId) -> [EntityId] {
-        guard let node = findNode(entityId, in: tree) else { return [] }
-        var result: [EntityId] = []
-        func collect(_ tree: EntityTree) {
-            for child in tree.children ?? [] {
-                result.append(child.id)
-                collect(child)
-            }
-        }
-        collect(node)
-        return result
-    }
-
-    private func findNode(_ id: EntityId, in tree: EntityTree) -> EntityTree? {
-        if tree.id == id { return tree }
-        for child in tree.children ?? [] {
-            if let found = findNode(id, in: child) {
-                return found
-            }
-        }
-        return nil
-    }
-
-    mutating func insertEntity(
-        _ eId: EntityId,
-        intoTree tree: inout EntityTree,
-        withParent pId: EntityId
-    ) -> Bool {
-        if tree.id == pId {
-            tree.addChild(EntityTree(id: eId))
-            return true
-        } else {
-            for i in 0..<tree.childCount {
-                if var children = tree.children, insertEntity(eId, intoTree: &children[i], withParent: pId) {
-                    tree.children = children
-                    return true
-                }
-            }
-        }
-        return false
-    }
-    
-    mutating func moveEntity(
-        _ eId: EntityId,
-        toParent pId: EntityId,
-        inTree tree: inout EntityTree
-    ) {
-        guard var e = entities[eId] else {
-            assert(entities[eId] != nil, "expected entity to exist")
-            return
-        }
-        
-        let resultRemove = removeEntity(eId, fromTree: &tree)
-        assert(resultRemove, "Failed to find entity in tree '\(eId)'")
-        let resultInsert = insertEntity(eId, intoTree: &tree, withParent: pId)
-        assert(resultInsert, "Failed to find parent in tree '\(pId)'")
-        
-        e.parentId = pId
-        entities[eId] = e
-    }
-    
-    mutating func removeEntity(
-        _ eId: EntityId,
-        fromTree tree: inout EntityTree
-    ) -> Bool {
-            for i in 0..<tree.childCount {
-                if tree.children?[i].id == eId {
-                    tree.children?.remove(at: i)
-                    return true
-                } else if var children = tree.children, removeEntity(eId, fromTree: &children[i]) {
-                    tree.children = children
-                    return true
-                }
-            }
-        return false
+        hierarchy.descendants(of: entityId)
     }
 }

--- a/Sources/RedECS/Entity/GameEntity.swift
+++ b/Sources/RedECS/Entity/GameEntity.swift
@@ -22,18 +22,3 @@ public struct GameEntity: Hashable, Identifiable, Codable {
         self.parentId = parentId
     }
 }
-
-public struct EntityTree: Hashable, Codable, Identifiable {
-    public var id: EntityId
-    public var children: [EntityTree]?
-    
-    public var childCount: Int { children?.count ?? 0 }
-    
-    mutating func addChild(_ c: EntityTree) {
-        if children == nil {
-            children = [c]
-        } else {
-            children?.append(c)
-        }
-    }
-}

--- a/Sources/RedECS/Rendering/RenderableComponent.swift
+++ b/Sources/RedECS/Rendering/RenderableComponent.swift
@@ -69,7 +69,7 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
             renderer.setProjectionMatrix(projectionMatrix)
 
             enqueue(
-                childrenOf: state.entities.tree,
+                children: state.entities.hierarchy.roots,
                 worldMatrix: .identity,
                 state: state,
                 projectionMatrix: projectionMatrix,
@@ -80,26 +80,26 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
         return .none
     }
 
-    /// Walks the entity tree depth-first, composing each entity's transform
+    /// Walks the entity forest depth-first, composing each entity's transform
     /// with its ancestors' so children render in their parent's frame.
     /// A hidden entity hides its entire subtree.
     private func enqueue(
-        childrenOf tree: EntityTree,
+        children: [EntityId],
         worldMatrix: Matrix3,
         state: State,
         projectionMatrix: Matrix3,
         environment: RenderingEnvironment,
         order: ((EntityId, State) -> Double)? = nil
     ) {
-        for node in Self.ordered(tree.children ?? [], by: order, in: state) {
-            let transform = state.transform[node.id]
+        for entityId in Self.ordered(children, by: order, in: state) {
+            let transform = state.transform[entityId]
             if transform?.isHidden == true {
                 continue
             }
 
             if let transform = transform {
                 for type in renderableComponentTypes {
-                    guard let renderComponent = type.renderComponent(entityId: node.id, state: state) else {
+                    guard let renderComponent = type.renderComponent(entityId: entityId, state: state) else {
                         continue
                     }
                     let groups = renderComponent.renderGroups(
@@ -117,7 +117,7 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
             // anchor-point offset (that only affects the parent's own drawing).
             let childWorldMatrix = transform.map { .multiply(worldMatrix, $0.matrix()) } ?? worldMatrix
             enqueue(
-                childrenOf: node,
+                children: state.entities.hierarchy.children(of: entityId),
                 worldMatrix: childWorldMatrix,
                 state: state,
                 projectionMatrix: projectionMatrix,
@@ -129,15 +129,15 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
     /// Stable: entities with an equal key keep the order they were added in,
     /// so a tie can't shimmer between frames.
     private static func ordered(
-        _ nodes: [EntityTree],
+        _ ids: [EntityId],
         by order: ((EntityId, State) -> Double)?,
         in state: State
-    ) -> [EntityTree] {
-        guard let order else { return nodes }
-        return nodes
+    ) -> [EntityId] {
+        guard let order else { return ids }
+        return ids
             .enumerated()
             .sorted { a, b in
-                let ka = order(a.element.id, state), kb = order(b.element.id, state)
+                let ka = order(a.element, state), kb = order(b.element, state)
                 return ka == kb ? a.offset < b.offset : ka < kb
             }
             .map(\.element)

--- a/Tests/RedECSTests/EntityHierarchyTests.swift
+++ b/Tests/RedECSTests/EntityHierarchyTests.swift
@@ -20,7 +20,7 @@ final class EntityHierarchyTests: XCTestCase {
         store.sendSystemAction(.addEntity("a", []))
 
         XCTAssertEqual(store.state.entities["a"]?.parentId, EntityRepository.Constants.rootTreeId)
-        XCTAssertEqual(store.state.entities.tree.children?.map(\.id), ["a"])
+        XCTAssertEqual(store.state.entities.hierarchy.roots, ["a"])
     }
 
     func testAddAndRemoveTagKeepsReverseIndexInSync() {
@@ -114,7 +114,57 @@ final class EntityHierarchyTests: XCTestCase {
         XCTAssertNil(store.state.entities["child"])
         XCTAssertNil(store.state.entities["grandchild"])
         XCTAssertNil(store.state.transform["grandchild"], "components of removed descendants should be destroyed")
-        XCTAssertEqual(store.state.entities.tree.childCount, 0)
+        XCTAssertTrue(store.state.entities.hierarchy.roots.isEmpty)
+    }
+
+    func testSetParentKeepsMovedSubtree() {
+        let store = makeStore()
+        store.sendSystemAction(.addEntity("newParent", []))
+        store.sendSystemAction(.addEntity("mover", []))
+        store.sendSystemAction(.addEntity("child", []))
+        store.sendSystemAction(.addEntity("grandchild", []))
+        store.sendSystemAction(.setParent("child", "mover"))
+        store.sendSystemAction(.setParent("grandchild", "child"))
+
+        store.sendSystemAction(.setParent("mover", "newParent"))
+
+        XCTAssertEqual(store.state.entities["mover"]?.parentId, "newParent")
+        XCTAssertEqual(store.state.entities.descendants(of: "newParent"), ["mover", "child", "grandchild"])
+        XCTAssertEqual(store.state.entities.descendants(of: "mover"), ["child", "grandchild"])
+    }
+
+    func testSetParentToRootKeepsMovedSubtree() {
+        let store = makeStore()
+        store.sendSystemAction(.addEntity("container", []))
+        store.sendSystemAction(.addEntity("mover", []))
+        store.sendSystemAction(.addEntity("child", []))
+        store.sendSystemAction(.setParent("mover", "container"))
+        store.sendSystemAction(.setParent("child", "mover"))
+
+        store.sendSystemAction(.setParent("mover", nil))
+
+        XCTAssertEqual(store.state.entities["mover"]?.parentId, EntityRepository.Constants.rootTreeId)
+        XCTAssertEqual(store.state.entities.descendants(of: "mover"), ["child"])
+        XCTAssertEqual(store.state.entities.descendants(of: "container"), [])
+        XCTAssertEqual(store.state.entities.hierarchy.roots, ["container", "mover"])
+    }
+
+    func testRemoveEntityCascadesThroughMovedSubtree() {
+        let store = makeStore()
+        store.sendSystemAction(.addEntity("newParent", []))
+        store.sendSystemAction(.addEntity("mover", []))
+        store.sendSystemAction(.addEntity("child", []))
+        store.sendSystemAction(.setParent("child", "mover"))
+        store.sendSystemAction(.addComponent(TransformComponent(entity: "child"), into: \.transform))
+
+        store.sendSystemAction(.setParent("mover", "newParent"))
+        store.sendSystemAction(.removeEntity("newParent"))
+
+        XCTAssertNil(store.state.entities["newParent"])
+        XCTAssertNil(store.state.entities["mover"])
+        XCTAssertNil(store.state.entities["child"])
+        XCTAssertNil(store.state.transform["child"])
+        XCTAssertTrue(store.state.entities.hierarchy.roots.isEmpty)
     }
 
     func testStateSurvivesCodingRoundTripWithHierarchy() throws {

--- a/known-issues.md
+++ b/known-issues.md
@@ -17,15 +17,6 @@ record of what changed and when.
   Cause: the `AnyReducer` it builds stubs the delta and entityEvent positions with
   `{ _,_,_ in .none }` instead of forwarding to `self.reduce`.
 
-- **`setParent` drops the moved entity's entire subtree from the render tree**
-  Where: `Sources/RedECS/Entity/EntityRepository.swift:140-142`
-  Symptom: reparenting an entity that has children makes all descendants vanish
-  from rendering; later `removeEntity` no longer cascades to them (leak).
-  Cause: `removeEntity(_:fromTree:)` removes the node *with* its children, then
-  `insertEntity` re-inserts a fresh childless node. Also: if the new parent is a
-  descendant of the moved entity (or missing), the insert fails and in release
-  builds the entity disappears from the tree entirely (assert-only guard).
-
 - **Cold `Future` re-executes work per subscribe; `zip` can double-resolve**
   Where: `Sources/RedECS/Utilities/Future.swift:11-15, 69-86, 120-131`
   Symptom: multiple subscriptions re-run the underlying load; zero subscriptions
@@ -45,7 +36,7 @@ record of what changed and when.
 - **`newEntityId()` is collision-prone and nondeterministic**
   Where: `Sources/RedECS/Entity/GameEntity.swift:5`
   Symptom: possible silent state corruption on ID collision (duplicate-entity
-  check is assert-only, `EntityRepository.swift:29`); replay/lockstep determinism
+  check is assert-only, `EntityRepository.swift:31`); replay/lockstep determinism
   impossible; weaker on wasm32 where `Int` is 32-bit.
   Cause: two `Int.random` values concatenated without a separator (so distinct
   pairs can collide textually), system RNG. Known TODO in code.
@@ -88,7 +79,7 @@ record of what changed and when.
   tick (`SpriteComponent.swift:106-107`) — animations run slower than authored.
 
 - **Camera selection uses an invalid sort comparator**
-  Where: `Sources/RedECS/Rendering/RenderableComponent.swift:50`
+  Where: `Sources/RedECS/Rendering/RenderableComponent.swift:63`
   Symptom: with >1 camera, the chosen camera is nondeterministic frame-to-frame
   (and the comparator violates strict weak ordering).
   Cause: `sorted(by: { $1.isPrimaryCamera ? false : true })` never inspects `$0`,
@@ -269,7 +260,7 @@ is no benchmark target — so treat the ordering as untested. Added 2026-07-31.
 - **`Matrix3` is heap-backed, so every transform costs 4+ allocations**
   Where: `Geometry` 0.0.5, `Sources/GeometryAlgorithms/Matrix3/Matrix3.swift:5`;
   felt at `Sources/RedECS/Rendering/Transform/TransformComponent.swift:35-41` and
-  `Sources/RedECS/Rendering/RenderableComponent.swift:91,96,103`
+  `Sources/RedECS/Rendering/RenderableComponent.swift:106,111,118`
   Symptom: allocation churn scaling with entity count × tree depth, on every frame.
   Cause: `Matrix3` stores `values: [Double]` and every operation returns a new matrix
   built from an array literal. `TransformComponent.matrix()` chains `.identity →
@@ -278,7 +269,7 @@ is no benchmark target — so treat the ordering as untested. Added 2026-07-31.
   `Double`s in the Geometry package (needs a coordinated release).
 
 - **The render walk copies whole game state per node, per renderable type**
-  Where: `Sources/RedECS/Rendering/RenderableComponent.swift:18,26-28,87`
+  Where: `Sources/RedECS/Rendering/RenderableComponent.swift:18,26-28,102`
   Symptom: per-frame cost scales with (tree nodes × registered renderable types) even
   for entities that have none of those components.
   Cause: `RenderableComponentType.getRenderComponent` is `(EntityId, State) -> …`,


### PR DESCRIPTION
## What this changes

The entity hierarchy moves from the naive recursive `EntityTree` to `OrderedForest<EntityId>` from the Graphs package (RedECSEngine/Graphs#1) — a proper adjacency-based forest with the hierarchy invariants enforced at the type level.

**What this buys:**
- Parent/children lookups drop from O(n) full-tree searches to O(1); reparent and removal no longer recursively copy tree spines.
- The dual-source-of-truth bookkeeping (`parentId` + nested tree, hand-synced) is gone: the forest is the single source of truth, and `GameEntity.parentId` is a repository-synced convenience. The `setParent` subtree-drop bug class is now **unrepresentable** — `move` validates before mutating and a subtree always travels intact (known-issues entry deleted; its behavior tests are ported here).
- `removeEntity` on the repository now sweeps the whole returned subtree (entities + tags), so direct repository-level removal is leak-free; the `GameStore` deepest-first cascade is unchanged.
- A failed spawn under a missing parent now falls back to a root insert in release instead of leaving the entity invisible and un-cascadable.

**API surface:** `EntityRepository.tree` becomes `hierarchy: OrderedForest<EntityId>`; `EntityTree` and the tree-manipulation trio (`insertEntity(_:intoTree:withParent:)`, `moveEntity(_:toParent:inTree:)`, `removeEntity(_:fromTree:)`) are deleted outright (no downstream users existed). `Constants.rootTreeId` survives only as the `parentId` sentinel — top-level entities are forest-native roots, and every existing `parentId == "Root"` assertion still holds. `addEntity`/`removeEntity`/`setParent`/`descendants(of:)`/tags are unchanged in signature and semantics.

**Save format:** the Codable payload's `tree` key becomes `hierarchy` with a flat validated format — an accepted break; old saves will not decode.

**Rendering:** the render walk is a mechanical port from tree nodes to `hierarchy.roots` / `children(of:)`. Draw order is bit-identical by construction — **all Metal snapshot suites pass with zero re-recorded references**.

## Dependency note

Temporarily consumes Graphs via `.package(path: "../swift-graphs")`. Pre-merge checklist:
1. Merge RedECSEngine/Graphs#1, tag `0.1.0`, push the tag.
2. Flip to `.package(url: "https://github.com/RedECSEngine/Graphs.git", from: "0.1.0")` and re-run full verification.

## Verification

- Full `swift test`: 264 tests, 0 failures; `__Snapshots__` untouched.
- `git grep EntityTree` in Sources returns nothing.
- Wasm: `RedECSWebSupport` builds with Graphs compiled for wasm (the package is now import-free of Foundation).
- Both existing Graphs consumers (swift-random-dungeon-generator, DungeonCleanersKit) build against the new Graphs branch.

Follow-up (separate PR): rebase the scene-support branch (#13) onto this — its `setParent` fix commit becomes obsolete, and `SceneReducer` teardown plus the sceneAware render walk get reworked onto the forest API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)