### PR TITLE
Derive entity parentage from the hierarchy

### DIFF
--- a/Sources/RedECS/Entity/EntityRepository.swift
+++ b/Sources/RedECS/Entity/EntityRepository.swift
@@ -27,20 +27,17 @@ public struct EntityRepository: Equatable, Codable {
 // MARK: - Entity Lifecycle
 
 public extension EntityRepository {
-    mutating func addEntity(_ e: GameEntity) {
+    mutating func addEntity(_ e: GameEntity, under parentId: EntityId? = nil) {
         assert(entities[e.id] == nil, "adding duplicate entity \(e.id)")
-        var e = e
         e.tags.forEach { tag in
             tags[tag, default: []].insert(e.id)
         }
 
-        var parentId = e.parentId.flatMap { $0 == Constants.rootTreeId ? nil : $0 }
-        if !hierarchy.insert(e.id, under: parentId) {
+        let target = parentId.flatMap { $0 == Constants.rootTreeId ? nil : $0 }
+        if !hierarchy.insert(e.id, under: target) {
             assertionFailure("Failed to find parent '\(parentId ?? Constants.rootTreeId)' for entity '\(e.id)'")
-            parentId = nil
             hierarchy.insert(e.id, under: nil)
         }
-        e.parentId = parentId ?? Constants.rootTreeId
         entities[e.id] = e
     }
 
@@ -82,7 +79,10 @@ public extension EntityRepository {
             assertionFailure("Failed to move entity '\(entityId)' under '\(parentId ?? Constants.rootTreeId)'")
             return
         }
-        entities[entityId]?.parentId = target ?? Constants.rootTreeId
+    }
+
+    func parent(of entityId: EntityId) -> EntityId? {
+        hierarchy.parent(of: entityId)
     }
 
     /// All ids in the subtree rooted at `entityId`, depth-first,

--- a/Sources/RedECS/Entity/GameEntity.swift
+++ b/Sources/RedECS/Entity/GameEntity.swift
@@ -9,16 +9,13 @@ public func newEntityId(prefix: String? = nil) -> EntityId {
 
 public struct GameEntity: Hashable, Identifiable, Codable {
     public var id: EntityId
-    public var parentId: EntityId?
     public var tags: Set<String>
-    
+
     public init(
         id: EntityId,
-        tags: Set<String>,
-        parentId: EntityId? = nil
+        tags: Set<String>
     ) {
         self.id = id
         self.tags = tags
-        self.parentId = parentId
     }
 }

--- a/Sources/RedECS/Store/GameStore.swift
+++ b/Sources/RedECS/Store/GameStore.swift
@@ -120,7 +120,7 @@ public final class GameStore<R: Reducer> where R.State: OperationCapableGameStat
     }
 
     public func addEntity(_ id: EntityId, tags: Set<String>, parentId: EntityId? = nil) -> GameEffect<R.State, R.Action> {
-        state.entities.addEntity(GameEntity(id: id, tags: tags, parentId: parentId))
+        state.entities.addEntity(GameEntity(id: id, tags: tags), under: parentId)
         return reducer.reduce(state: &state, entityEvent: .added(id), environment: environment)
     }
 

--- a/Tests/RedECSTests/EntityHierarchyTests.swift
+++ b/Tests/RedECSTests/EntityHierarchyTests.swift
@@ -19,7 +19,7 @@ final class EntityHierarchyTests: XCTestCase {
         let store = makeStore()
         store.sendSystemAction(.addEntity("a", []))
 
-        XCTAssertEqual(store.state.entities["a"]?.parentId, EntityRepository.Constants.rootTreeId)
+        XCTAssertNil(store.state.entities.parent(of: "a"))
         XCTAssertEqual(store.state.entities.hierarchy.roots, ["a"])
     }
 
@@ -68,12 +68,12 @@ final class EntityHierarchyTests: XCTestCase {
         store.sendSystemAction(.addEntity("child", []))
         store.sendSystemAction(.setParent("child", "parent"))
 
-        XCTAssertEqual(store.state.entities["child"]?.parentId, "parent")
+        XCTAssertEqual(store.state.entities.parent(of: "child"), "parent")
         XCTAssertEqual(store.state.entities.descendants(of: "parent"), ["child"])
 
         // and back to the root
         store.sendSystemAction(.setParent("child", nil))
-        XCTAssertEqual(store.state.entities["child"]?.parentId, EntityRepository.Constants.rootTreeId)
+        XCTAssertNil(store.state.entities.parent(of: "child"))
         XCTAssertEqual(store.state.entities.descendants(of: "parent"), [])
     }
 
@@ -128,7 +128,7 @@ final class EntityHierarchyTests: XCTestCase {
 
         store.sendSystemAction(.setParent("mover", "newParent"))
 
-        XCTAssertEqual(store.state.entities["mover"]?.parentId, "newParent")
+        XCTAssertEqual(store.state.entities.parent(of: "mover"), "newParent")
         XCTAssertEqual(store.state.entities.descendants(of: "newParent"), ["mover", "child", "grandchild"])
         XCTAssertEqual(store.state.entities.descendants(of: "mover"), ["child", "grandchild"])
     }
@@ -143,7 +143,7 @@ final class EntityHierarchyTests: XCTestCase {
 
         store.sendSystemAction(.setParent("mover", nil))
 
-        XCTAssertEqual(store.state.entities["mover"]?.parentId, EntityRepository.Constants.rootTreeId)
+        XCTAssertNil(store.state.entities.parent(of: "mover"))
         XCTAssertEqual(store.state.entities.descendants(of: "mover"), ["child"])
         XCTAssertEqual(store.state.entities.descendants(of: "container"), [])
         XCTAssertEqual(store.state.entities.hierarchy.roots, ["container", "mover"])
@@ -176,7 +176,7 @@ final class EntityHierarchyTests: XCTestCase {
         let data = try JSONEncoder().encode(store.state)
         let restored = try JSONDecoder().decode(TestGlobalState.self, from: data)
 
-        XCTAssertEqual(restored.entities["child"]?.parentId, "parent")
+        XCTAssertEqual(restored.entities.parent(of: "child"), "parent")
         XCTAssertEqual(restored.entities.descendants(of: "parent"), ["child"])
     }
 }


### PR DESCRIPTION
Follow-up to #14: removes the last remnant of dual parentage bookkeeping.

- `GameEntity` is now `{ id, tags }` — the stored, repository-synced `parentId` is gone. The `OrderedForest` is the only place parentage lives, so a stale parent value is no longer possible even in principle.
- Parent is an explicit spawn argument: `EntityRepository.addEntity(_ e:, under: EntityId? = nil)`. `GameStore.addEntity(_:tags:parentId:)` forwards unchanged, so store-level callers are unaffected.
- Queries go through the new `EntityRepository.parent(of:)` — O(1), `nil` for root-level entities. `Constants.rootTreeId` survives only as a forgiving *input* sentinel (`under: "Root"` still means root); queries speak `nil`.
- `GameEntity`'s Codable shape changes (save break — accepted, stacking on #14's break while the engine is nascent and saves are cheap to regenerate).

Known downstream fallout (expected, per ecosystem rules — not fixed here): dungeon-cleaners' `GameSnapshotTests` reads `entities[childId]?.parentId` in two places and will need `entities.parent(of: childId)`. Scene PR #13 needs one more rebase onto this — its root-level check actually simplifies (`parent(of:) == nil` instead of the sentinel comparison).

Verification: 264 tests green, snapshot references untouched, wasm build of `RedECSWebSupport` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)