### PR TITLE
Rendering performance: Metal encode batching, boxing and CoW fixes, Geometry 0.0.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c69da3054392501da4a4d39044d28f7638f50ef0b270d40144e47e82f49ab767",
+  "originHash" : "5f0fba68aa6b1c36b813b3f00ae45852c5f927879aeb1755272a685468daac27",
   "pins" : [
     {
       "identity" : "geometry",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RedECSEngine/Geometry.git",
       "state" : {
-        "revision" : "90247082d2e42f726a6e6a17a877b3ad9a059629",
-        "version" : "0.0.5"
+        "revision" : "92514af3db789d5e5afd8afd32b19953dcf55fd6",
+        "version" : "0.0.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/RedECSEngine/Geometry.git",
-            from: "0.0.5"
+            from: "0.0.7"
         ),
 
         .package(

--- a/Sources/RedECS/Rendering/RenderTriangle.swift
+++ b/Sources/RedECS/Rendering/RenderTriangle.swift
@@ -181,7 +181,5 @@ public struct RenderTriangle {
 }
 
 public extension RenderTriangle {
-    static var noTextureTriangle: Triangle {
-        Triangle(a: .init(x: -1, y: -1), b: .init(x: -1, y: -1), c: .init(x: -1, y: -1))
-    }
+    static let noTextureTriangle = Triangle(a: .init(x: -1, y: -1), b: .init(x: -1, y: -1), c: .init(x: -1, y: -1))
 }

--- a/Sources/RedECS/Rendering/RenderableComponent.swift
+++ b/Sources/RedECS/Rendering/RenderableComponent.swift
@@ -15,16 +15,29 @@ public protocol RenderableGameState: GameState {
 }
 
 public struct RenderableComponentType<State: GameState> {
-    var getRenderComponent: (EntityId, State) -> RenderableComponent?
-    
+    var produceRenderGroups: (EntityId, State, Matrix3, TransformComponent, ResourceManager) -> [RenderGroup]?
+
     public init<C: RenderableComponent>(keyPath: KeyPath<State, [EntityId: C]>) {
-        getRenderComponent = { id, gameState in
-            gameState[keyPath: keyPath][id]
+        produceRenderGroups = { entityId, state, cameraMatrix, transform, resourceManager in
+            guard let component = state[keyPath: keyPath][entityId] else {
+                return nil
+            }
+            return component.renderGroups(
+                cameraMatrix: cameraMatrix,
+                transform: transform,
+                resourceManager: resourceManager
+            )
         }
     }
-    
-    func renderComponent(entityId: EntityId, state: State) -> RenderableComponent? {
-       getRenderComponent(entityId, state)
+
+    func renderGroups(
+        entityId: EntityId,
+        state: State,
+        cameraMatrix: Matrix3,
+        transform: TransformComponent,
+        resourceManager: ResourceManager
+    ) -> [RenderGroup]? {
+        produceRenderGroups(entityId, state, cameraMatrix, transform, resourceManager)
     }
 }
 
@@ -32,7 +45,7 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
     public typealias State = ContextState
     public typealias Action = Never
     public typealias Environment = RenderingEnvironment
-    
+
     var renderableComponentTypes: [RenderableComponentType<State>]
     var rootDrawOrder: ((EntityId, State) -> Double)?
 
@@ -59,10 +72,10 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
         delta: Double,
         environment: RenderingEnvironment
     ) -> GameEffect<State, Never> {
-        
+
         if let camera = state.camera.values.sorted(by: { $1.isPrimaryCamera ? false : true }).first,
            let transform = state.transform[camera.entity] {
-            
+
             let renderer = environment.renderer
             let size = renderer.viewportSize
             let projectionMatrix = camera.matrix(withRect: Rect(center: transform.position, size: size))
@@ -91,6 +104,7 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
         environment: RenderingEnvironment,
         order: ((EntityId, State) -> Double)? = nil
     ) {
+        let cameraMatrix = Matrix3.multiply(projectionMatrix, worldMatrix)
         for entityId in Self.ordered(children, by: order, in: state) {
             let transform = state.transform[entityId]
             if transform?.isHidden == true {
@@ -99,14 +113,15 @@ public struct RenderingReducer<ContextState: RenderableGameState>: Reducer {
 
             if let transform = transform {
                 for type in renderableComponentTypes {
-                    guard let renderComponent = type.renderComponent(entityId: entityId, state: state) else {
-                        continue
-                    }
-                    let groups = renderComponent.renderGroups(
-                        cameraMatrix: .multiply(projectionMatrix, worldMatrix),
+                    guard let groups = type.renderGroups(
+                        entityId: entityId,
+                        state: state,
+                        cameraMatrix: cameraMatrix,
                         transform: transform,
                         resourceManager: environment.resourceManager
-                    )
+                    ) else {
+                        continue
+                    }
                     environment.renderer.enqueue(groups.map { group in
                         group.withTransformMatrix(.multiply(worldMatrix, group.transformMatrix))
                     })

--- a/Sources/RedECS/Rendering/Sprite/SpriteAnimatingReducer.swift
+++ b/Sources/RedECS/Rendering/Sprite/SpriteAnimatingReducer.swift
@@ -36,12 +36,10 @@ public struct SpriteAnimatingReducer: Reducer {
         environment: RenderingEnvironment
     ) -> GameEffect<SpriteContext, SpriteAnimatingAction> {
         var effects: [GameEffect<SpriteContext, SpriteAnimatingAction>] = []
-        state.sprite.forEach { (id, spriteComponent) in
-            var sprite = spriteComponent
-            if let completedAnimationId = sprite.applyDelta(delta) {
+        for id in Array(state.sprite.keys) {
+            if let completedAnimationId = state.sprite[id]?.applyDelta(delta) {
                 effects.append(.game(.animationComplete(completedAnimationId)))
             }
-            state.sprite[id] = sprite
         }
         return .many(effects)
     }

--- a/Sources/RedECSAppleSupport/MetalRenderer.swift
+++ b/Sources/RedECSAppleSupport/MetalRenderer.swift
@@ -241,42 +241,39 @@ public class MetalRenderer: NSObject, MTKViewDelegate {
             let color = renderGroup.color?.asVectorFloat4 ?? vector_float4(0, 0, 0, Float(renderGroup.opacity))
             var triangleVertices: [AAPLVertex] = []
             var textureVertices: [TextureInfo] = []
+            triangleVertices.reserveCapacity(renderGroup.triangles.count * 3)
+            textureVertices.reserveCapacity(renderGroup.triangles.count * 3)
             var uniforms = Uniforms(
                 projectionMatrix: renderGroup.projectionSpace == .screen
                     ? screenProjectionMatrix
                     : projectionMatrix,
                 modelViewMatrix: renderGroup.transformMatrix.asMatrix4x4
             )
-            
+
+            var texSize = vector_float2(0, 0)
+            if let textureId = renderGroup.textureId,
+               let texture = resourceManager.textureImages[textureId] {
+                texSize.x = Float(texture.width)
+                texSize.y = Float(texture.height)
+            }
+
             for renderTriangle in renderGroup.triangles {
-                triangleVertices.append(contentsOf: [
-                    AAPLVertex(
-                        position: renderTriangle.triangle.a.asVectorFloat2,
-                        color: color
-                    ),
-                    AAPLVertex(
-                        position: renderTriangle.triangle.b.asVectorFloat2,
-                        color: color
-                    ),
-                    AAPLVertex(
-                        position: renderTriangle.triangle.c.asVectorFloat2,
-                        color: color
-                    )
-                ])
-                var texSize = vector_float2(0, 0)
-                if let textureId = renderGroup.textureId,
-                   let texture = resourceManager.textureImages[textureId] {
-                    texSize.x = Float(texture.width)
-                    texSize.y = Float(texture.height)
-                }
-                textureVertices.append(contentsOf: [
-                    TextureInfo(
-                        texCoord: (renderTriangle.textureTriangle ?? RenderTriangle.noTextureTriangle) .a.asVectorFloat2, texSize: texSize),
-                    TextureInfo(
-                        texCoord: (renderTriangle.textureTriangle ?? RenderTriangle.noTextureTriangle) .b.asVectorFloat2, texSize: texSize),
-                    TextureInfo(
-                        texCoord: (renderTriangle.textureTriangle ?? RenderTriangle.noTextureTriangle) .c.asVectorFloat2, texSize: texSize),
-                ])
+                triangleVertices.append(AAPLVertex(
+                    position: renderTriangle.triangle.a.asVectorFloat2,
+                    color: color
+                ))
+                triangleVertices.append(AAPLVertex(
+                    position: renderTriangle.triangle.b.asVectorFloat2,
+                    color: color
+                ))
+                triangleVertices.append(AAPLVertex(
+                    position: renderTriangle.triangle.c.asVectorFloat2,
+                    color: color
+                ))
+                let textureTriangle = renderTriangle.textureTriangle ?? RenderTriangle.noTextureTriangle
+                textureVertices.append(TextureInfo(texCoord: textureTriangle.a.asVectorFloat2, texSize: texSize))
+                textureVertices.append(TextureInfo(texCoord: textureTriangle.b.asVectorFloat2, texSize: texSize))
+                textureVertices.append(TextureInfo(texCoord: textureTriangle.c.asVectorFloat2, texSize: texSize))
             }
             
             if let textureId = renderGroup.textureId {
@@ -306,18 +303,30 @@ public class MetalRenderer: NSObject, MTKViewDelegate {
 
             renderEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: AAPLVertexInputIndex.uniforms.rawValue)
             
-            let chunkAmount = 3
-            for i in 0..<(triangleVertices.count / chunkAmount) {
-                let index = i * chunkAmount
-                renderEncoder.setVertexBytes(Array(triangleVertices[index..<index+chunkAmount]), length:  MemoryLayout<AAPLVertex>.size * chunkAmount, index: AAPLVertexInputIndex.indices.rawValue)
-                
-                renderEncoder.setVertexBytes(Array(textureVertices[index..<index+chunkAmount]), length: MemoryLayout<TextureInfo>.size * chunkAmount, index: AAPLVertexInputIndex.textureCoordinates.rawValue)
-                
-                renderEncoder.drawPrimitives(
-                    type: .triangle,
-                    vertexStart: 0,
-                    vertexCount: chunkAmount
-                )
+            let maxChunkVertices = 126
+            triangleVertices.withUnsafeBufferPointer { positions in
+                textureVertices.withUnsafeBufferPointer { texCoords in
+                    var index = 0
+                    while index < positions.count {
+                        let chunk = min(maxChunkVertices, positions.count - index)
+                        renderEncoder.setVertexBytes(
+                            positions.baseAddress! + index,
+                            length: MemoryLayout<AAPLVertex>.stride * chunk,
+                            index: AAPLVertexInputIndex.indices.rawValue
+                        )
+                        renderEncoder.setVertexBytes(
+                            texCoords.baseAddress! + index,
+                            length: MemoryLayout<TextureInfo>.stride * chunk,
+                            index: AAPLVertexInputIndex.textureCoordinates.rawValue
+                        )
+                        renderEncoder.drawPrimitives(
+                            type: .triangle,
+                            vertexStart: 0,
+                            vertexCount: chunk
+                        )
+                        index += chunk
+                    }
+                }
             }
         }
         


### PR DESCRIPTION
## What

Profile-driven rendering performance fixes. An earlier version of this branch added a render-group memoization cache; CPU traces showed it didn't reduce frame cost (its hash roughly replaced the generation work it saved), so it's gone. What remains is the set of changes that measurably moved the needle or removes real per-frame waste:

- **Metal encode batching** (`MetalRenderer`): draw in 126-vertex (42-triangle) chunks — the 4KB `setVertexBytes` limit — instead of one draw call per triangle, passing pointers into the vertex arrays instead of allocating two `Array(slice)` copies per draw. Build-phase fixes: `reserveCapacity`, per-vertex appends instead of throwaway 3-element array literals, the `texSize` texture lookup hoisted from per-triangle to per-group, and `RenderTriangle.noTextureTriangle` is a stored constant. In a CPU Profiler trace of a full-map HUD tilemap scene, encoding was ~70% of frame cost, nearly all of it allocator/refcount traffic from the per-triangle loop; this collapses it.
- **No more per-entity existential boxing** (`RenderableComponentType`): the stored closure now performs the component lookup and `renderGroups` call with the concrete component type and returns `[RenderGroup]?`, instead of returning a `RenderableComponent` existential — which heap-boxed every `SpriteComponent` (embedding its whole `TiledMapJSON`) per entity per frame. Also hoists the per-level `projection × world` multiply out of the entity loop.
- **`SpriteAnimatingReducer` CoW fix**: iterate materialized keys and mutate through the dictionary subscript in place, instead of writing `state.sprite[id] = sprite` while `forEach` holds a second buffer reference — which forced a full dictionary copy per sprite per frame.
- **Geometry 0.0.7**: brings `Shape.line`, `Matrix3: Hashable`, and the `Matrix3` rewrite to fixed-size inline storage (nine stored `Double`s, `values` now computed) so every matrix op in the engine is allocation-free — `transform.matrix()` alone was ~5 heap allocations, run multiple times per entity per frame.

## Verification

- Full suite passes (264 tests) with all Metal/HUD snapshots bit-identical — the encode chunking and matrix storage changes are exact-output-preserving.
- `RedECSWebSupport` builds for wasm32.
- Traced with Instruments CPU Profiler before/after on dungeon-cleaners: the HUD-tilemap-heavy scene dropped substantially (encode overhead was its dominant cost); gameplay scenes are bounded by game logic and geometry regeneration, addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

