### PR TITLE
CSVInterpreter: a Foundation-free CSV decoder, and loadCSVFile

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,11 @@ let package = Package(
             name: "TiledInterpreter",
             targets: ["TiledInterpreter"]
         ),
+
+        .library(
+            name: "CSVInterpreter",
+            targets: ["CSVInterpreter"]
+        ),
     ],
     dependencies: [
         .package(
@@ -124,6 +129,11 @@ let package = Package(
             dependencies: []
         ),
 
+        .target(
+            name: "CSVInterpreter",
+            dependencies: []
+        ),
+
         .testTarget(
             name: "RedECSTests",
             dependencies: ["RedECS", "RedECSBasicComponents", "RedECSAppleSupport"]
@@ -152,6 +162,11 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .testTarget(
+            name: "CSVInterpreterTests",
+            dependencies: ["CSVInterpreter"]
+        ),
+
         .testTarget(
             name: "TiledInterpreterTests",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -114,12 +114,13 @@ let package = Package(
 
         .target(
             name: "RedECSAppleSupport",
-            dependencies: ["RedECSKit"]
+            dependencies: ["RedECSKit", "CSVInterpreter"]
         ),
         .target(
             name: "RedECSWebSupport",
             dependencies: [
                 "RedECSKit",
+                "CSVInterpreter",
                 .product(name: "JavaScriptKit", package: "JavaScriptKit")
             ]
         ),

--- a/Sources/CSVInterpreter/CSVCodingKey.swift
+++ b/Sources/CSVInterpreter/CSVCodingKey.swift
@@ -1,0 +1,14 @@
+struct CSVCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = Int(stringValue)
+    }
+
+    init(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String(intValue)
+    }
+}

--- a/Sources/CSVInterpreter/CSVColumnTree.swift
+++ b/Sources/CSVInterpreter/CSVColumnTree.swift
@@ -1,0 +1,57 @@
+struct CSVColumnTree: Equatable, Sendable {
+    var columnIndex: Int?
+    var childNames: [String] = []
+    var children: [String: CSVColumnTree] = [:]
+
+    func child(named name: String) -> CSVColumnTree? { children[name] }
+
+    func hasValue(in row: [String]) -> Bool {
+        if let columnIndex {
+            return !row.cell(at: columnIndex).isEmpty
+        }
+        for name in childNames where children[name]?.hasValue(in: row) == true {
+            return true
+        }
+        return false
+    }
+
+    static func build(headers: [String]) throws -> CSVColumnTree {
+        var root = CSVColumnTree()
+        var seen: Set<String> = []
+        for (index, header) in headers.enumerated() {
+            let path = header.split(separator: ".").map(String.init)
+            guard !header.isEmpty, !path.isEmpty else {
+                throw CSVError.emptyColumnName(index: index)
+            }
+            guard seen.insert(header).inserted else {
+                throw CSVError.duplicateColumn(header)
+            }
+            try root.insert(path: path[...], columnIndex: index, header: header)
+        }
+        return root
+    }
+
+    private mutating func insert(
+        path: ArraySlice<String>,
+        columnIndex index: Int,
+        header: String
+    ) throws {
+        guard let name = path.first else {
+            guard columnIndex == nil, children.isEmpty else {
+                throw CSVError.conflictingColumn(header)
+            }
+            columnIndex = index
+            return
+        }
+        guard columnIndex == nil else { throw CSVError.conflictingColumn(header) }
+        if children[name] == nil {
+            children[name] = CSVColumnTree()
+            childNames.append(name)
+        }
+        try children[name]!.insert(
+            path: path.dropFirst(),
+            columnIndex: index,
+            header: header
+        )
+    }
+}

--- a/Sources/CSVInterpreter/CSVDecoder.swift
+++ b/Sources/CSVInterpreter/CSVDecoder.swift
@@ -1,0 +1,15 @@
+public struct CSVDecoder: Sendable {
+    public var delimiter: Character
+
+    public init(delimiter: Character = ",") {
+        self.delimiter = delimiter
+    }
+
+    public func decode<T: Decodable>(_ type: T.Type, from text: String) throws -> T {
+        try decode(type, from: CSVTable.parse(text, delimiter: delimiter))
+    }
+
+    public func decode<T: Decodable>(_ type: T.Type, from table: CSVTable) throws -> T {
+        try T(from: CSVTableDecoder(table: table))
+    }
+}

--- a/Sources/CSVInterpreter/CSVDecoding.swift
+++ b/Sources/CSVInterpreter/CSVDecoding.swift
@@ -1,0 +1,318 @@
+struct CSVTableDecoder: Decoder {
+    let table: CSVTable
+
+    var codingPath: [CodingKey] { [] }
+    var userInfo: [CodingUserInfoKey: Any] { [:] }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        CSVRowsDecodingContainer(table: table)
+    }
+
+    func container<Key: CodingKey>(
+        keyedBy type: Key.Type
+    ) throws -> KeyedDecodingContainer<Key> {
+        try singleRowDecoder().container(keyedBy: type)
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        try singleRowDecoder().singleValueContainer()
+    }
+
+    private func singleRowDecoder() throws -> CSVRowDecoder {
+        guard table.rows.count == 1 else {
+            throw CSVError.expectedSingleRow(found: table.rows.count)
+        }
+        return CSVRowDecoder(columns: table.columns, row: table.rows[0], codingPath: [])
+    }
+}
+
+struct CSVRowsDecodingContainer: UnkeyedDecodingContainer {
+    let table: CSVTable
+    let codingPath: [CodingKey] = []
+    var currentIndex: Int = 0
+
+    var count: Int? { table.rows.count }
+    var isAtEnd: Bool { currentIndex >= table.rows.count }
+
+    mutating func decodeNil() throws -> Bool { false }
+
+    mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        try T(from: nextDecoder())
+    }
+
+    mutating func nestedContainer<NestedKey: CodingKey>(
+        keyedBy type: NestedKey.Type
+    ) throws -> KeyedDecodingContainer<NestedKey> {
+        try nextDecoder().container(keyedBy: type)
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        try nextDecoder().unkeyedContainer()
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+        try nextDecoder()
+    }
+
+    private mutating func nextDecoder() throws -> CSVRowDecoder {
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(Any.self, .init(
+                codingPath: codingPath,
+                debugDescription: "No row at index \(currentIndex)"
+            ))
+        }
+        let index = currentIndex
+        currentIndex += 1
+        return CSVRowDecoder(
+            columns: table.columns,
+            row: table.rows[index],
+            codingPath: [CSVCodingKey(intValue: index)]
+        )
+    }
+}
+
+struct CSVRowDecoder: Decoder {
+    let columns: CSVColumnTree
+    let row: [String]
+    let codingPath: [CodingKey]
+
+    var userInfo: [CodingUserInfoKey: Any] { [:] }
+
+    func container<Key: CodingKey>(
+        keyedBy type: Key.Type
+    ) throws -> KeyedDecodingContainer<Key> {
+        guard columns.columnIndex == nil else {
+            throw DecodingError.typeMismatch([String: Any].self, .init(
+                codingPath: codingPath,
+                debugDescription: "\"\(pathDescription)\" is a single column; "
+                    + "expected sub-columns such as \"\(pathDescription).<field>\""
+            ))
+        }
+        return KeyedDecodingContainer(CSVKeyedDecodingContainer<Key>(
+            columns: columns,
+            row: row,
+            codingPath: codingPath
+        ))
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        try CSVIndexedDecodingContainer(
+            columns: columns,
+            row: row,
+            codingPath: codingPath
+        )
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        guard let columnIndex = columns.columnIndex else {
+            throw DecodingError.typeMismatch(String.self, .init(
+                codingPath: codingPath,
+                debugDescription: "\"\(pathDescription)\" is a group of columns, not a value"
+            ))
+        }
+        return CSVSingleValueDecodingContainer(
+            decoder: self,
+            cell: row.cell(at: columnIndex)
+        )
+    }
+
+    var pathDescription: String {
+        codingPath.map(\.stringValue).joined(separator: ".")
+    }
+}
+
+struct CSVKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+    let columns: CSVColumnTree
+    let row: [String]
+    let codingPath: [CodingKey]
+
+    var allKeys: [Key] { columns.childNames.compactMap(Key.init(stringValue:)) }
+
+    func contains(_ key: Key) -> Bool {
+        columns.child(named: key.stringValue) != nil
+    }
+
+    func decodeNil(forKey key: Key) throws -> Bool {
+        guard let child = columns.child(named: key.stringValue) else { return true }
+        return !child.hasValue(in: row)
+    }
+
+    func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        try T(from: decoder(for: key))
+    }
+
+    func nestedContainer<NestedKey: CodingKey>(
+        keyedBy type: NestedKey.Type,
+        forKey key: Key
+    ) throws -> KeyedDecodingContainer<NestedKey> {
+        try decoder(for: key).container(keyedBy: type)
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        try decoder(for: key).unkeyedContainer()
+    }
+
+    func superDecoder() throws -> Decoder {
+        CSVRowDecoder(columns: columns, row: row, codingPath: codingPath)
+    }
+
+    func superDecoder(forKey key: Key) throws -> Decoder {
+        try decoder(for: key)
+    }
+
+    private func decoder(for key: Key) throws -> CSVRowDecoder {
+        guard let child = columns.child(named: key.stringValue) else {
+            throw DecodingError.keyNotFound(key, .init(
+                codingPath: codingPath,
+                debugDescription: "No column named \"\(key.stringValue)\""
+            ))
+        }
+        return CSVRowDecoder(columns: child, row: row, codingPath: codingPath + [key])
+    }
+}
+
+struct CSVIndexedDecodingContainer: UnkeyedDecodingContainer {
+    private let elements: [CSVColumnTree]
+    private let row: [String]
+    let codingPath: [CodingKey]
+    var currentIndex: Int = 0
+
+    init(columns: CSVColumnTree, row: [String], codingPath: [CodingKey]) throws {
+        if let columnIndex = columns.columnIndex {
+            guard row.cell(at: columnIndex).isEmpty else {
+                throw DecodingError.typeMismatch([Any].self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected indexed sub-columns such as \"0\", \"1\"; "
+                        + "found a single column holding \"\(row.cell(at: columnIndex))\""
+                ))
+            }
+            self.elements = []
+            self.row = row
+            self.codingPath = codingPath
+            return
+        }
+
+        var indexed: [(Int, CSVColumnTree)] = []
+        for name in columns.childNames {
+            guard let position = Int(name), let child = columns.child(named: name) else {
+                throw DecodingError.typeMismatch([Any].self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected indexed sub-columns such as \"0\", \"1\"; "
+                        + "found \"\(name)\""
+                ))
+            }
+            indexed.append((position, child))
+        }
+        indexed.sort { $0.0 < $1.0 }
+
+        var ordered = indexed.map(\.1)
+        while let last = ordered.last, !last.hasValue(in: row) {
+            ordered.removeLast()
+        }
+
+        self.elements = ordered
+        self.row = row
+        self.codingPath = codingPath
+    }
+
+    var count: Int? { elements.count }
+    var isAtEnd: Bool { currentIndex >= elements.count }
+
+    mutating func decodeNil() throws -> Bool {
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(Any.self, .init(
+                codingPath: codingPath,
+                debugDescription: "No element at index \(currentIndex)"
+            ))
+        }
+        guard !elements[currentIndex].hasValue(in: row) else { return false }
+        currentIndex += 1
+        return true
+    }
+
+    mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        try T(from: nextDecoder())
+    }
+
+    mutating func nestedContainer<NestedKey: CodingKey>(
+        keyedBy type: NestedKey.Type
+    ) throws -> KeyedDecodingContainer<NestedKey> {
+        try nextDecoder().container(keyedBy: type)
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        try nextDecoder().unkeyedContainer()
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+        try nextDecoder()
+    }
+
+    private mutating func nextDecoder() throws -> CSVRowDecoder {
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(Any.self, .init(
+                codingPath: codingPath,
+                debugDescription: "No element at index \(currentIndex)"
+            ))
+        }
+        let element = elements[currentIndex]
+        let key = CSVCodingKey(intValue: currentIndex)
+        currentIndex += 1
+        return CSVRowDecoder(columns: element, row: row, codingPath: codingPath + [key])
+    }
+}
+
+struct CSVSingleValueDecodingContainer: SingleValueDecodingContainer {
+    let decoder: CSVRowDecoder
+    let cell: String
+
+    var codingPath: [CodingKey] { decoder.codingPath }
+
+    func decodeNil() -> Bool { cell.isEmpty }
+
+    func decode(_ type: String.Type) throws -> String { cell }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+        switch CSVText.trimmed(cell).lowercased() {
+        case "true", "yes", "1": return true
+        case "false", "no", "0": return false
+        default: throw mismatch(Bool.self)
+        }
+    }
+
+    func decode(_ type: Double.Type) throws -> Double { try convert { Double($0) } }
+    func decode(_ type: Float.Type) throws -> Float { try convert { Float($0) } }
+    func decode(_ type: Int.Type) throws -> Int { try convert { Int($0) } }
+    func decode(_ type: Int8.Type) throws -> Int8 { try convert { Int8($0) } }
+    func decode(_ type: Int16.Type) throws -> Int16 { try convert { Int16($0) } }
+    func decode(_ type: Int32.Type) throws -> Int32 { try convert { Int32($0) } }
+    func decode(_ type: Int64.Type) throws -> Int64 { try convert { Int64($0) } }
+    func decode(_ type: UInt.Type) throws -> UInt { try convert { UInt($0) } }
+    func decode(_ type: UInt8.Type) throws -> UInt8 { try convert { UInt8($0) } }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { try convert { UInt16($0) } }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { try convert { UInt32($0) } }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { try convert { UInt64($0) } }
+
+    func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        try T(from: decoder)
+    }
+
+    private func convert<T>(_ make: (String) -> T?) throws -> T {
+        let text = CSVText.trimmed(cell)
+        guard !text.isEmpty else {
+            throw DecodingError.valueNotFound(T.self, .init(
+                codingPath: codingPath,
+                debugDescription: "Cell is empty"
+            ))
+        }
+        guard let value = make(text) else { throw mismatch(T.self) }
+        return value
+    }
+
+    private func mismatch<T>(_ type: T.Type) -> DecodingError {
+        DecodingError.typeMismatch(type, .init(
+            codingPath: codingPath,
+            debugDescription: "\"\(cell)\" is not a valid \(type)"
+        ))
+    }
+}

--- a/Sources/CSVInterpreter/CSVError.swift
+++ b/Sources/CSVInterpreter/CSVError.swift
@@ -1,0 +1,10 @@
+public enum CSVError: Error, Equatable, Sendable {
+    case emptyDocument
+    case unterminatedQuote(line: Int)
+    case unexpectedQuote(line: Int)
+    case emptyColumnName(index: Int)
+    case duplicateColumn(String)
+    case conflictingColumn(String)
+    case tooManyValues(row: Int, expected: Int, found: Int)
+    case expectedSingleRow(found: Int)
+}

--- a/Sources/CSVInterpreter/CSVParser.swift
+++ b/Sources/CSVInterpreter/CSVParser.swift
@@ -1,0 +1,70 @@
+enum CSVParser {
+    static func parse(_ text: String, delimiter: Character) throws -> [[String]] {
+        var rows: [[String]] = []
+        var fields: [String] = []
+        var field = ""
+        var inQuotes = false
+        var rowHasContent = false
+        var line = 1
+        var quoteStartLine = 1
+
+        var index = text.startIndex
+        if text.first == "\u{FEFF}" {
+            index = text.index(after: index)
+        }
+
+        while index < text.endIndex {
+            let character = text[index]
+
+            if inQuotes {
+                if character == "\"" {
+                    let next = text.index(after: index)
+                    if next < text.endIndex, text[next] == "\"" {
+                        field.append("\"")
+                        index = text.index(after: next)
+                    } else {
+                        inQuotes = false
+                        index = next
+                    }
+                } else {
+                    if character.isCSVRowTerminator { line += 1 }
+                    field.append(character)
+                    index = text.index(after: index)
+                }
+                continue
+            }
+
+            switch character {
+            case "\"":
+                guard field.isEmpty else { throw CSVError.unexpectedQuote(line: line) }
+                inQuotes = true
+                quoteStartLine = line
+                rowHasContent = true
+            case delimiter:
+                fields.append(field)
+                field = ""
+                rowHasContent = true
+            case let terminator where terminator.isCSVRowTerminator:
+                fields.append(field)
+                field = ""
+                if rowHasContent { rows.append(fields) }
+                fields = []
+                rowHasContent = false
+                line += 1
+            default:
+                field.append(character)
+                rowHasContent = true
+            }
+            index = text.index(after: index)
+        }
+
+        guard !inQuotes else { throw CSVError.unterminatedQuote(line: quoteStartLine) }
+
+        if rowHasContent {
+            fields.append(field)
+            rows.append(fields)
+        }
+
+        return rows
+    }
+}

--- a/Sources/CSVInterpreter/CSVTable.swift
+++ b/Sources/CSVInterpreter/CSVTable.swift
@@ -1,0 +1,76 @@
+public struct CSVTable: Equatable, Sendable {
+    public let headers: [String]
+    public let rows: [[String]]
+    let columns: CSVColumnTree
+
+    public init(headers: [String], rows: [[String]]) throws {
+        let names = headers.map(CSVText.trimmed)
+        for (index, row) in rows.enumerated() where row.count > names.count {
+            throw CSVError.tooManyValues(
+                row: index,
+                expected: names.count,
+                found: row.count
+            )
+        }
+        self.headers = names
+        self.rows = rows
+        self.columns = try CSVColumnTree.build(headers: names)
+    }
+
+    public static func parse(
+        _ text: String,
+        delimiter: Character = ","
+    ) throws -> CSVTable {
+        let lines = try CSVParser.parse(text, delimiter: delimiter)
+        guard let header = lines.first else { throw CSVError.emptyDocument }
+        return try CSVTable(headers: header, rows: Array(lines.dropFirst()))
+    }
+
+    public func serialized(
+        delimiter: Character = ",",
+        lineTerminator: String = "\n"
+    ) -> String {
+        guard !headers.isEmpty else { return "" }
+        var output = ""
+        append(headers, to: &output, delimiter: delimiter, lineTerminator: lineTerminator)
+        for row in rows {
+            append(row, to: &output, delimiter: delimiter, lineTerminator: lineTerminator)
+        }
+        return output
+    }
+
+    private func append(
+        _ values: [String],
+        to output: inout String,
+        delimiter: Character,
+        lineTerminator: String
+    ) {
+        for (index, value) in values.enumerated() {
+            if index > 0 { output.append(delimiter) }
+            output.append(CSVTable.escaped(value, delimiter: delimiter))
+        }
+        output.append(contentsOf: lineTerminator)
+    }
+
+    static func escaped(_ value: String, delimiter: Character) -> String {
+        var needsQuotes = value.first == " " || value.last == " "
+        if !needsQuotes {
+            for character in value {
+                if character == delimiter
+                    || character == "\""
+                    || character.isCSVRowTerminator {
+                    needsQuotes = true
+                    break
+                }
+            }
+        }
+        guard needsQuotes else { return value }
+        var quoted = "\""
+        for character in value {
+            if character == "\"" { quoted.append("\"") }
+            quoted.append(character)
+        }
+        quoted.append("\"")
+        return quoted
+    }
+}

--- a/Sources/CSVInterpreter/CSVText.swift
+++ b/Sources/CSVInterpreter/CSVText.swift
@@ -1,0 +1,26 @@
+enum CSVText {
+    static let whitespace: Set<Character> = [" ", "\t", "\n", "\r", "\r\n"]
+
+    static func trimmed(_ value: String) -> String {
+        var slice = value[...]
+        while let first = slice.first, whitespace.contains(first) {
+            slice = slice.dropFirst()
+        }
+        while let last = slice.last, whitespace.contains(last) {
+            slice = slice.dropLast()
+        }
+        return String(slice)
+    }
+}
+
+extension Character {
+    var isCSVRowTerminator: Bool {
+        self == "\n" || self == "\r\n" || self == "\r"
+    }
+}
+
+extension [String] {
+    func cell(at index: Int) -> String {
+        indices.contains(index) ? self[index] : ""
+    }
+}

--- a/Sources/RedECS/ResourceManager.swift
+++ b/Sources/RedECS/ResourceManager.swift
@@ -39,6 +39,7 @@ public protocol ResourceManager: AnyObject {
     func animationsForTexture(_ textureId: TextureId) -> SpriteAnimationDictionary?
     
     func loadJSONFile<T: Decodable>(_ name: String, decodedAs: T.Type) -> Future<T, Error>
+    func loadCSVFile<T: Decodable>(_ name: String, decodedAs: T.Type) -> Future<T, Error>
     func loadTiledMap(_ name: String) -> Future<TiledMapJSON, Error>
     func loadBitmapFontTextFile(_ name: String) -> Future<BitmapFont, Error>
 }

--- a/Sources/RedECSAppleSupport/MetalResourceManager.swift
+++ b/Sources/RedECSAppleSupport/MetalResourceManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CSVInterpreter
 import RedECS
 import RedHUD
 import TiledInterpreter
@@ -141,6 +142,40 @@ public final class MetalResourceManager: ResourceManager {
             .toVoid()
     }
     
+    public func loadCSVFile<T: Decodable>(
+        _ name: String,
+        decodedAs: T.Type
+    ) -> Future<T, Swift.Error> {
+        var name = name
+        var ext = "csv"
+        let nameSplit = name.split(separator: ".")
+        if nameSplit.count > 1 {
+            name = String(nameSplit.dropLast().joined(separator: "."))
+            ext = String(nameSplit[nameSplit.count - 1])
+        }
+        return Future { (resolve: (Result<T, Error>) -> Void) in
+            guard let path = self.resourceBundle.path(forResource: name, ofType: ext) else {
+                resolve(.failure(MetalResourceManagerError.fileNotFound("\(name).\(ext) in \(self.resourceBundle.description)")))
+                return
+            }
+
+            let url = URL(fileURLWithPath: path)
+
+            guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+                  let string = String(data: data, encoding: .utf8) else {
+                resolve(.failure(MetalResourceManagerError.fileLoadFailure(url.absoluteString)))
+                return
+            }
+
+            do {
+                let decoded = try CSVDecoder().decode(T.self, from: string)
+                resolve(.success(decoded))
+            } catch {
+                resolve(.failure(MetalResourceManagerError.fileDecodeFailure("\(name).\(ext):" + String(describing: error))))
+            }
+        }
+    }
+
     public func loadTiledMap(_ name: String) -> Future<TiledMapJSON, Swift.Error> {
         return loadJSONFile(name, decodedAs: TiledMapJSON.self)
             .flatMap { tileMap -> Future<TiledMapJSON, Swift.Error> in

--- a/Sources/RedECSWebSupport/WebResourceManager.swift
+++ b/Sources/RedECSWebSupport/WebResourceManager.swift
@@ -1,4 +1,5 @@
 import JavaScriptKit
+import CSVInterpreter
 import RedECS
 import RedHUD
 import TiledInterpreter
@@ -111,6 +112,46 @@ public final class WebResourceManager: ResourceManager {
         }
     }
     
+    public func loadCSVFile<T: Decodable>(
+        _ name: String,
+        decodedAs: T.Type
+    ) -> Future<T, Swift.Error> {
+        Future { (resolve: @escaping (Result<T, Swift.Error>) -> Void) in
+            guard let origin = JSObject.global.window.object?.location.object?.origin.string else {
+                resolve(.failure(WebResourceManagerError.windowLocationOriginNotAvailable))
+                return
+            }
+            guard let fetchFunc = JSObject.global.fetch.function else {
+                resolve(.failure(WebResourceManagerError.jsFetchFunctionNotAvailable))
+                return
+            }
+
+            let url = origin + "/" + self.resourcePath + "/" + name
+
+            (JSPromise(from: fetchFunc(url)))?
+                .then(success: { response in
+                    JSPromise(from: response.text())?.jsValue ?? .null
+                })
+                .then(success: { value in
+                    guard let text = value.string else {
+                        resolve(.failure(WebResourceManagerError.fileDecodeFailure("\(name):")))
+                        return JSValue.null
+                    }
+                    do {
+                        let decoded = try CSVDecoder().decode(T.self, from: text)
+                        resolve(.success(decoded))
+                    } catch {
+                        resolve(.failure(WebResourceManagerError.fileDecodeFailure("\(name):" + String(describing: error))))
+                    }
+                    return JSValue.null
+                }, failure: { error in
+                    print("error", error)
+                    resolve(.failure(WebResourceManagerError.jsError(String(describing: error.jsValue))))
+                    return JSValue.null
+                })
+        }
+    }
+
     public func loadImageFile(
         name: String
     ) -> Future<JSValue, Swift.Error> {

--- a/Tests/CSVInterpreterTests/CSVInterpreterTests.swift
+++ b/Tests/CSVInterpreterTests/CSVInterpreterTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import CSVInterpreter
+
+private struct Stats: Codable, Equatable {
+    var hp: Int
+    var strength: Int
+}
+
+private enum School: String, Codable {
+    case fire
+    case frost
+}
+
+private struct Ability: Codable, Equatable {
+    var code: String
+    var name: String
+    var cooldown: Double
+    var isPassive: Bool
+    var stats: Stats
+    var tags: [String]
+    var nickname: String?
+}
+
+final class CSVTableTests: XCTestCase {
+    func testQuotedFieldsWithDelimitersNewlinesAndEscapes() throws {
+        let csv = "a,b,c\r\n"
+            + "\"x,y\",\"he said \"\"hi\"\"\",\"line\ntwo\"\r\n"
+        let table = try CSVTable.parse(csv)
+        XCTAssertEqual(table.headers, ["a", "b", "c"])
+        XCTAssertEqual(table.rows, [["x,y", "he said \"hi\"", "line\ntwo"]])
+    }
+
+    func testBlankLinesAndBOMAreIgnored() throws {
+        let table = try CSVTable.parse("\u{FEFF}a,b\n\n1,2\n\n")
+        XCTAssertEqual(table.headers, ["a", "b"])
+        XCTAssertEqual(table.rows, [["1", "2"]])
+    }
+
+    func testShortRowsAreKeptAndLongRowsThrow() throws {
+        XCTAssertEqual(try CSVTable.parse("a,b,c\n1,2").rows, [["1", "2"]])
+        XCTAssertThrowsError(try CSVTable.parse("a,b\n1,2,3")) { error in
+            XCTAssertEqual(error as? CSVError, .tooManyValues(row: 0, expected: 2, found: 3))
+        }
+    }
+
+    func testUnterminatedQuoteReportsWhereItOpened() {
+        XCTAssertThrowsError(try CSVTable.parse("a\n\"oops\n")) { error in
+            XCTAssertEqual(error as? CSVError, .unterminatedQuote(line: 2))
+        }
+    }
+
+    func testDuplicateAndConflictingColumnsThrow() {
+        XCTAssertThrowsError(try CSVTable.parse("a,a\n1,2")) { error in
+            XCTAssertEqual(error as? CSVError, .duplicateColumn("a"))
+        }
+        XCTAssertThrowsError(try CSVTable.parse("s,s.hp\n1,2")) { error in
+            XCTAssertEqual(error as? CSVError, .conflictingColumn("s.hp"))
+        }
+        XCTAssertThrowsError(try CSVTable.parse("s.hp,s\n1,2")) { error in
+            XCTAssertEqual(error as? CSVError, .conflictingColumn("s"))
+        }
+    }
+
+    func testCustomDelimiter() throws {
+        let table = try CSVTable.parse("a;b\n1;2", delimiter: ";")
+        XCTAssertEqual(table.rows, [["1", "2"]])
+    }
+
+    func testSerializationQuotesOnlyWhereNeededAndSurvivesReparsing() throws {
+        let table = try CSVTable(
+            headers: ["a", "b", "c"],
+            rows: [
+                ["plain", "has,comma", "has\"quote"],
+                [" pad ", "line\nbreak", ""]
+            ]
+        )
+        XCTAssertEqual(table.serialized(), """
+        a,b,c
+        plain,"has,comma","has""quote"
+        " pad ","line\nbreak",
+
+        """)
+        XCTAssertEqual(try CSVTable.parse(table.serialized()).rows, table.rows)
+    }
+}
+
+final class CSVDecoderTests: XCTestCase {
+    func testDecodesNestedRows() throws {
+        let csv = """
+        code,name,cooldown,isPassive,stats.hp,stats.strength,tags.0,tags.1,nickname
+        fire,Fire,2500,false,10,4,magical,fire,Boom
+        heal,Heal, 1000 ,TRUE,12,1,magical,,
+        """
+        let abilities = try CSVDecoder().decode([Ability].self, from: csv)
+
+        XCTAssertEqual(abilities.count, 2)
+        XCTAssertEqual(abilities[0], Ability(
+            code: "fire",
+            name: "Fire",
+            cooldown: 2500,
+            isPassive: false,
+            stats: Stats(hp: 10, strength: 4),
+            tags: ["magical", "fire"],
+            nickname: "Boom"
+        ))
+        XCTAssertEqual(abilities[1].cooldown, 1000)
+        XCTAssertEqual(abilities[1].isPassive, true)
+        XCTAssertEqual(abilities[1].tags, ["magical"])
+        XCTAssertNil(abilities[1].nickname)
+    }
+
+    func testEmptyCellIsNilForOptionalAndEmptyStringForRequired() throws {
+        struct Row: Codable { var name: String; var nickname: String? }
+        let rows = try CSVDecoder().decode([Row].self, from: "name,nickname\n,\n")
+        XCTAssertEqual(rows[0].name, "")
+        XCTAssertNil(rows[0].nickname)
+    }
+
+    func testRawRepresentableEnum() throws {
+        struct Row: Codable { var school: School }
+        let rows = try CSVDecoder().decode([Row].self, from: "school\nfrost")
+        XCTAssertEqual(rows[0].school, .frost)
+    }
+
+    func testInteriorBlankSurvivesAndTrailingBlankTrims() throws {
+        struct Row: Codable { var tags: [String?] }
+        let rows = try CSVDecoder().decode(
+            [Row].self,
+            from: "tags.0,tags.1,tags.2\na,,c\na,,\n"
+        )
+        XCTAssertEqual(rows[0].tags, ["a", nil, "c"])
+        XCTAssertEqual(rows[1].tags, ["a"])
+    }
+
+    func testSparseIndicesCollapseInSortedOrder() throws {
+        struct Row: Codable { var tags: [String] }
+        let rows = try CSVDecoder().decode(
+            [Row].self,
+            from: "tags.2,tags.0\nlast,first\n"
+        )
+        XCTAssertEqual(rows[0].tags, ["first", "last"])
+    }
+
+    func testEmptyLeafDecodesAsEmptyArrayAndNonEmptyLeafThrows() throws {
+        struct Row: Codable { var code: String; var tags: [String] }
+        let rows = try CSVDecoder().decode([Row].self, from: "code,tags\na,\n")
+        XCTAssertEqual(rows[0].tags, [])
+        XCTAssertThrowsError(try CSVDecoder().decode([Row].self, from: "code,tags\na,boom\n"))
+    }
+
+    func testOptionalNestedGroupIsNilWhenWhollyEmpty() throws {
+        struct Row: Codable { var code: String; var stats: Stats? }
+        let rows = try CSVDecoder().decode(
+            [Row].self,
+            from: "code,stats.hp,stats.strength\na,,\nb,1,2"
+        )
+        XCTAssertNil(rows[0].stats)
+        XCTAssertEqual(rows[1].stats, Stats(hp: 1, strength: 2))
+    }
+
+    func testSingleRowDecodesIntoAStruct() throws {
+        let stats = try CSVDecoder().decode(Stats.self, from: "hp,strength\n3,4")
+        XCTAssertEqual(stats, Stats(hp: 3, strength: 4))
+        XCTAssertThrowsError(
+            try CSVDecoder().decode(Stats.self, from: "hp,strength\n3,4\n5,6")
+        ) { error in
+            XCTAssertEqual(error as? CSVError, .expectedSingleRow(found: 2))
+        }
+    }
+
+    func testMissingColumnReportsKeyNotFound() {
+        XCTAssertThrowsError(
+            try CSVDecoder().decode([Stats].self, from: "hp\n3")
+        ) { error in
+            guard case let .keyNotFound(key, _)? = error as? DecodingError else {
+                return XCTFail("expected keyNotFound, got \(error)")
+            }
+            XCTAssertEqual(key.stringValue, "strength")
+        }
+    }
+
+    func testBadNumberReportsCodingPath() {
+        XCTAssertThrowsError(
+            try CSVDecoder().decode([Stats].self, from: "hp,strength\nx,4")
+        ) { error in
+            guard case let .typeMismatch(_, context)? = error as? DecodingError else {
+                return XCTFail("expected typeMismatch, got \(error)")
+            }
+            XCTAssertEqual(context.codingPath.map(\.stringValue), ["0", "hp"])
+        }
+    }
+
+    func testHeaderOnlyDecodesAsEmptyArray() throws {
+        XCTAssertEqual(try CSVDecoder().decode([Stats].self, from: "hp,strength\n"), [])
+    }
+}


### PR DESCRIPTION
Adds `CSVInterpreter`, a standalone target mirroring `TiledInterpreter` — no dependencies and no imports. `Codable`/`Decoder`/`DecodingError` are stdlib rather than Foundation, so the module cross-compiles to wasm; input is `String`, not `Data`, for the same reason.

### Why build rather than depend

Every credible Swift CSV-Codable package imports Foundation, verified by reading their sources: [CodableCSV](https://github.com/dehesa/CodableCSV), [CSV.swift](https://github.com/yaslab/CSV.swift), [skelpo/CSV](https://github.com/skelpo/CSV), [benkoska/CSV.Swift](https://github.com/benkoska/CSV.Swift), [Wouter01/swift-csv](https://github.com/Wouter01/swift-csv). skelpo/CSV is the closest miss — no package dependencies, WASM listed, Foundation-free *parser* — but its coder imports Foundation and it's untouched since 2021 on tools 5.0. Separately, none of them nest: CodableCSV's README states nested structures "are not supported by default in CSV implementations".

The architecture isn't novel and can't be — `Decoder` dictates the root-decoder-plus-containers skeleton, and letting a generic `decode<T>` witness the concrete requirements is standard practice. Specific to this design: the dotted/indexed header trie, empty-cell-means-nil, and trailing-array trimming.

### Shape

- Header rows carry structure through dotted paths: `stats.hp` opens a nested keyed container, `tags.0`/`tags.1` a nested unkeyed one.
- An empty cell decodes as nil; a required `String` still decodes as `""`.
- Trailing empties trim an array, so `magical,` over `tags.0,tags.1` is `["magical"]`.
- Rows shorter than the header pad; longer rows throw.
- `CSVTable` is public on its own, with `parse` and `serialized` as the symmetric pair.
- `CSVEncoder` is deliberately deferred — nothing writes CSV yet, and authoring happens in the spreadsheet.

The second commit adds `ResourceManager.loadCSVFile`, mirroring `loadJSONFile`: the same extension splitting on Apple, and on web a fetch that calls `response.text()` rather than `response.json()`. The protocol signature names only `Decodable`, so the `RedECS` target gains no dependency — only the two support targets that implement it link `CSVInterpreter`.

### Verification

- `swift build` clean; `swift test --filter 'CSVTableTests|CSVDecoderTests'` — **18/18 pass**
- `swiftly run swift build --swift-sdk 6.2-RELEASE-wasm32-unknown-wasip1 --target RedECSWebSupport +6.2.0` — clean, which is what actually proves the Foundation-free claim (Swift 5 mode's leaky member visibility hides violations on macOS)

### Downstream

`dungeon-cleaners#equipment-loot` consumes this by local path. Every stub `ResourceManager` in that repo's tests gained `loadCSVFile` alongside `loadJSONFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)